### PR TITLE
Upgrade TypeScript and modernize practices

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lsif-util": "^0.2.15",
     "prettier": "^1.19.1",
     "semantic-release": "^15.13.30",
-    "typescript": "^3.7.3"
+    "typescript": "^3.7.4"
   },
   "dependencies": {
     "iterare": "^1.2.0",

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -49,7 +49,7 @@ const extensions: Record<string, string | undefined> = {
 
 const lintMessageToDiagnostic = (lintMessage: eslint.Linter.LintMessage): lsp.Diagnostic => ({
     message: lintMessage.message,
-    code: lintMessage.ruleId || undefined,
+    code: lintMessage.ruleId ?? undefined,
     severity: severities[lintMessage.severity],
     source: 'eslint',
     range: {
@@ -58,8 +58,8 @@ const lintMessageToDiagnostic = (lintMessage: eslint.Linter.LintMessage): lsp.Di
             character: lintMessage.column - 1,
         },
         end: {
-            line: (lintMessage.endLine || lintMessage.line) - 1,
-            character: (lintMessage.endColumn || lintMessage.column) - 1,
+            line: (lintMessage.endLine ?? lintMessage.line) - 1,
+            character: (lintMessage.endColumn ?? lintMessage.column) - 1,
         },
     },
 })
@@ -114,7 +114,7 @@ function* lintResultToLSIF(result: eslint.CLIEngine.LintResult, data: FormatterD
         type: ElementTypes.vertex,
         label: VertexLabels.document,
         uri: pathToFileURL(result.filePath).href,
-        languageId: extensions[path.extname(result.filePath)] || 'javascript',
+        languageId: extensions[path.extname(result.filePath)] ?? 'javascript',
     }
     yield document
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@sourcegraph/tsconfig",
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2016",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5451,10 +5451,15 @@ typescript-json-schema@^0.36.0:
     typescript "^3.0.1"
     yargs "^12.0.1"
 
-typescript@^3.0.1, typescript@^3.7.3:
+typescript@^3.0.1:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uglify-js@^3.1.4:
   version "3.6.7"


### PR DESCRIPTION
- Use nullish coalescing, prefer readonly, and other TypeScript eslint fixes
- Upgrade TypeScript to a version that definitely supports these new features